### PR TITLE
run CI daily

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,8 @@
-on: ["push", "pull_request"]
+on:
+  push:
+  pull_request:
+  schedule:
+  - cron: 0 0 * * *  # midnight every day
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What I did

Add a schedule to the CI workflow to run daily.
Note that this will only be helpful if Github Actions notifications are enabled for failing builds. I do not have access to see that setting but that should be verified.

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
