### PR TITLE
Switch to built-in setuptools functionality

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,20 @@
 
 from setuptools import find_packages, setup
 
+with open('README.md', encoding="utf-8") as f:
+    long_description = f.read()
+
 setup(
     name="vvm",
     version="0.1.0",  # don't change this manually, use bumpversion instead
     description="Vyper version management tool",
-    long_description_markdown_filename="README.md",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author="Ben Hauser",
     author_email="ben@hauser.id",
     url="https://github.com/vyperlang/vvm",
     include_package_data=True,
     py_modules=["vvm"],
-    setup_requires=["setuptools-markdown"],
     python_requires=">=3.6, <4",
     install_requires=["requests>=2.19.0,<3", "semantic_version>=2.8.1,<3"],
     license="MIT",


### PR DESCRIPTION
Looks like setuptools-markdown is deprecated in favor of a built-in setuptools functionality.  Worse is that setuptools_markdown isn't compatible with a recent versions of a pypandoc library. Let's just drop it.

### What I did

Related issue: man-group/pytest-plugins#87

### How I did it
Stumbled upon this message while building:

```
/usr/bin/python3 setup.py build '--executable=/usr/bin/python3 -sP'
/usr/lib/python3.11/site-packages/setuptools/installer.py:27: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
  warnings.warn(
Traceback (most recent call last):
  File "/home/petro/rpmbuild/BUILD/vvm-0.1.0/setup.py", line 5, in <module>
    setup(
  File "/usr/lib/python3.11/site-packages/setuptools/__init__.py", line 87, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 139, in setup
    _setup_distribution = dist = klass(attrs)
                                 ^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/setuptools/dist.py", line 477, in __init__
    _Distribution.__init__(
  File "/usr/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 275, in __init__
    self.finalize_options()
  File "/usr/lib/python3.11/site-packages/setuptools/dist.py", line 901, in finalize_options
    ep(self)
  File "/usr/lib/python3.11/site-packages/setuptools/dist.py", line 922, in _finalize_setup_keywords
    ep.load()(self, ep.name, value)
  File "/home/petro/rpmbuild/BUILD/vvm-0.1.0/.eggs/setuptools_markdown-0.4.1-py3.11.egg/setuptools_markdown.py", line 43, in long_description_markdown_filename
    output = pypandoc.convert(markdown_filename, 'rst', format='md')
             ^^^^^^^^^^^^^^^^
AttributeError: module 'pypandoc' has no attribute 'convert'
```

### How to verify it
Run with a recent pypandoc. It will throw something like "AttributeError: module 'pypandoc' has no attribute 'convert'"

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
