### PR TITLE
fix: pep440 rc tags

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ black==19.10b0
 bumpversion==0.5.3
 flake8==3.8.3
 isort==4.3.21
-mypy==0.782
+mypy==0.982
 pytest>6.0.0,<7.0.0
 pytest-cov==2.10.1
 tox==3.18.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ follow_imports = silent
 [tool:isort]
 force_grid_wrap = 0
 include_trailing_comma = True
-known_third_party = pytest,requests,semantic_version,setuptools
+known_third_party = pytest,requests,packaging,setuptools
 line_length = 100
 multi_line_output = 3
 use_parentheses = True

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     include_package_data=True,
     py_modules=["vvm"],
     python_requires=">=3.6, <4",
-    install_requires=["requests>=2.19.0,<3", "semantic_version>=2.8.1,<3"],
+    install_requires=["requests>=2.19.0,<3", "packaging>=23.1,<24"],
     license="MIT",
     zip_safe=False,
     keywords="ethereum vyper",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 from requests import ConnectionError
-from semantic_version import Version
+from packaging.version import Version
 
 import vvm
 

--- a/tests/test_to_vyper_version.py
+++ b/tests/test_to_vyper_version.py
@@ -1,5 +1,5 @@
 import pytest
-from semantic_version import Version
+from packaging.version import Version
 
 from vvm.utils.convert import to_vyper_version
 

--- a/vvm/install.py
+++ b/vvm/install.py
@@ -27,7 +27,6 @@ except ImportError:
     tqdm = None
 
 
-BINARY_DOWNLOAD_BASE = "https://github.com/vyperlang/vyper/releases/download/v{}/{}"
 GITHUB_RELEASES = "https://api.github.com/repos/vyperlang/vyper/releases?per_page=100"
 
 LOGGER = logging.getLogger("vvm")
@@ -247,7 +246,7 @@ def install_vyper(
         headers = _get_headers(headers)
         data = _get_releases(headers)
         try:
-            release = next(i for i in data if i["tag_name"] == f"v{version}")
+            release = next(i for i in data if Version(i["tag_name"]) == version)
             asset = next(i for i in release["assets"] if _get_os_name() in i["name"])
         except StopIteration:
             raise VyperInstallationError(f"Vyper binary not available for v{version}")
@@ -256,7 +255,7 @@ def install_vyper(
         if os_name == "windows":
             install_path = install_path.with_name(f"{install_path.name}.exe")
 
-        url = BINARY_DOWNLOAD_BASE.format(version, asset["name"])
+        url = asset["browser_download_url"]
         content = _download_vyper(url, headers, show_progress)
         with open(install_path, "wb") as fp:
             fp.write(content)

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -3,7 +3,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from semantic_version import Version
+from packaging.version import Version
 
 from vvm import wrapper
 from vvm.exceptions import VyperError

--- a/vvm/utils/convert.py
+++ b/vvm/utils/convert.py
@@ -1,29 +1,16 @@
 from typing import Union
 
-from semantic_version import Version
+from packaging.version import Version
 
 
 def to_vyper_version(version: Union[str, Version]) -> Version:
     if not isinstance(version, Version):
-        version = Version.coerce(version.lstrip("v"))
+        version = Version(version)
 
-    if version.build and not version.prerelease:
-        version.prerelease = version.build
-        version.build = ()
-
-    if not version.prerelease:
+    if not version.pre:
         return version
 
-    version.prerelease = tuple(i.lower() for i in version.prerelease)
-
-    if len(version.prerelease) == 1:
-        # convert e.g. `beta17` or `B17` to `beta.17`
-        prerelease = version.prerelease[0]
-        if not prerelease[0].isdigit() and prerelease[-1].isdigit():
-            idx = prerelease.index(next(i for i in prerelease if i.isdigit()))
-            version.prerelease = prerelease[:idx], prerelease[idx:]
-
-    if version.prerelease[0] == "b":
-        version.prerelease = ("beta",) + version.prerelease[1:]
+    if version.pre[0] == "b":
+        version.pre = ("beta",) + version.prerelease[1:]
 
     return version

--- a/vvm/utils/convert.py
+++ b/vvm/utils/convert.py
@@ -7,10 +7,4 @@ def to_vyper_version(version: Union[str, Version]) -> Version:
     if not isinstance(version, Version):
         version = Version(version)
 
-    if not version.pre:
-        return version
-
-    if version.pre[0] == "b":
-        version.pre = ("beta",) + version.prerelease[1:]
-
     return version

--- a/vvm/wrapper.py
+++ b/vvm/wrapper.py
@@ -2,7 +2,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 
-from semantic_version import Version
+from packaging.version import Version
 
 from vvm import install
 from vvm.exceptions import UnknownOption, UnknownValue, VyperError


### PR DESCRIPTION
fix pep440 rc tags by removing the buggy `semantic-version` and using the `packaging` package provided by pypa.

also, bump mypy, as the the existing version would not build with python3.11.

### What I did

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
