### PR TITLE
feat: compile fns pass kwargs to vyper wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/vyperlang/vvm/)
+### Added
+- Support for specifing compiler flags
 
 ## [0.1.0](https://github.com/vyperlang/vvm/tree/v0.1.0) - 2020-10-07
 ### Added

--- a/tests/test_compile_source.py
+++ b/tests/test_compile_source.py
@@ -12,6 +12,9 @@ def test_compile_files(foo_path):
     output = vvm.compile_files([foo_path])
     assert foo_path.as_posix() in output
 
+def test_compile_to_ast(foo_source):
+    output = vvm.compile_source(foo_source, f="ast")
+    assert "ast" in output
 
 def test_compile_standard(input_json, foo_source):
     input_json["sources"] = {"contracts/Foo.vy": {"content": foo_source}}

--- a/tests/test_compile_source.py
+++ b/tests/test_compile_source.py
@@ -14,7 +14,7 @@ def test_compile_files(foo_path):
 
 def test_compile_to_ast(foo_source):
     output = vvm.compile_source(foo_source, f="ast")
-    assert "ast" in output
+    assert "ast" in output['<stdin>']
 
 def test_compile_standard(input_json, foo_source):
     input_json["sources"] = {"contracts/Foo.vy": {"content": foo_source}}

--- a/vvm/exceptions.py
+++ b/vvm/exceptions.py
@@ -60,6 +60,8 @@ class VyperInstallationError(Exception):
 class VyperNotInstalled(Exception):
     pass
 
+class VyperOutputError(Exception):
+    pass
 
 # Warnings
 

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 from packaging.version import Version
 
 from vvm import wrapper
-from vvm.exceptions import VyperError
+from vvm.exceptions import VyperError, VyperOutputError
 from vvm.install import get_executable
 
 
@@ -168,7 +168,11 @@ def _compile(
         vyper_binary=vyper_binary, f=output_format, p=base_path, **kwargs
     )
 
-    return json.loads(stdoutdata)
+    # TODO: This line throws when the specified output format is not valid json
+    try:
+        return json.loads(stdoutdata)
+    except json.JSONDecodeError:
+        raise VyperOutputError(f"Vyper output format {output_format} not valid JSON")
 
 
 def compile_standard(

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -85,6 +85,12 @@ def compile_source(
         **kwargs,
     )
 
+    if "f" in kwargs and kwargs["f"] != "combined_json":
+        data = {}
+        for format in kwargs["f"].split(","):
+            data[format] = compiler_data[format]
+        return {"<stdin>": data}
+
     return {"<stdin>": list(compiler_data.values())[0]}
 
 
@@ -153,12 +159,13 @@ def _compile(
     vyper_version: Optional[Version],
     **kwargs: Any,
 ) -> Dict:
-
     if vyper_binary is None:
         vyper_binary = get_executable(vyper_version)
 
+    output_format = kwargs.pop("f", "combined_json")
+
     stdoutdata, stderrdata, command, proc = wrapper.vyper_wrapper(
-        vyper_binary=vyper_binary, f="combined_json", p=base_path, **kwargs
+        vyper_binary=vyper_binary, f=output_format, p=base_path, **kwargs
     )
 
     return json.loads(stdoutdata)

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -29,6 +29,7 @@ def compile_source(
     evm_version: str = None,
     vyper_binary: Union[str, Path] = None,
     vyper_version: Version = None,
+    **kwargs: Any,
 ) -> Dict:
     """
     Compile a Vyper contract.
@@ -52,6 +53,20 @@ def compile_source(
         `vyper` version to use. If not given, the currently active version is used.
         Ignored if `vyper_binary` is also given.
 
+    Keyword Arguments
+    -----------------
+    **kwargs : Any
+        Flags to be passed to `vyper`. Keywords are converted to flags by prepending `--` and
+        replacing `_` with `-`, for example the keyword `evm_version` becomes `--evm-version`.
+        Values may be given in the following formats:
+
+            * `False`, `None`: ignored
+            * `True`: flag is used without any arguments
+            * str: given as an argument without modification
+            * int: given as an argument, converted to a string
+            * Path: converted to a string via `Path.as_posix()`
+            * List, Tuple: elements are converted to strings and joined with `,`
+
     Returns
     -------
     Dict
@@ -67,6 +82,7 @@ def compile_source(
         source_files=[source_path],
         base_path=base_path,
         evm_version=evm_version,
+        **kwargs,
     )
 
     return {"<stdin>": list(compiler_data.values())[0]}
@@ -78,6 +94,7 @@ def compile_files(
     evm_version: str = None,
     vyper_binary: Union[str, Path] = None,
     vyper_version: Version = None,
+    **kwargs: Any,
 ) -> Dict:
     """
     Compile one or more Vyper source files.
@@ -101,6 +118,20 @@ def compile_files(
         `vyper` version to use. If not given, the currently active version is used.
         Ignored if `vyper_binary` is also given.
 
+    Keyword Arguments
+    -----------------
+    **kwargs : Any
+        Flags to be passed to `vyper`. Keywords are converted to flags by prepending `--` and
+        replacing `_` with `-`, for example the keyword `evm_version` becomes `--evm-version`.
+        Values may be given in the following formats:
+
+            * `False`, `None`: ignored
+            * `True`: flag is used without any arguments
+            * str: given as an argument without modification
+            * int: given as an argument, converted to a string
+            * Path: converted to a string via `Path.as_posix()`
+            * List, Tuple: elements are converted to strings and joined with `,`
+
     Returns
     -------
     Dict
@@ -112,6 +143,7 @@ def compile_files(
         source_files=source_files,
         base_path=base_path,
         evm_version=evm_version,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
### What I did

The non-json compile functions exposed by VVM do not expose an interface for passing additional compiler flags to `vyper` when invoked.

This functinality, along with conversion of flags like "foo_bar" into "--foo-bar", is already implemented in vvm's wrapper module.

this PR simply passes along any uncaptured kwargs passed to `compile` or `compile_files` to enable specific use-cases.

because flags may be inconsistent across vyper versions, validation is left out of scope here. we're not offering options to the user, just letting them pass along ones they determine will be correct.

This currently does not support every case. There are some flags which we can pass that result in invalid json being output, which vvm will fail to parse. However this unblocks cases that do work (namely, building *just* the AST, for vyper-lsp performance)

### How I did it

added kwargs to `compile` and `compile_files`, and passed that arg to the call to `vyper.vyper_wrapper(..)`

if the `f` kwarg is present, we handle it specially, since we were hardcoding that to `combined_json`

There are some values for `f` that result in invalid JSON output from the compiler. This is currently as designed, but maybe should change. Perhaps if you want json you need to use `vyper-json`, but currently some output formats from plain `vyper` are valid JSON and others are not.

I added error handling for whenever a user specifies an output format that is not valid JSON. This will catch errors from any flags that result in non-JSON output.

Whether we should only use `vyper-json` when we need JSON output (therefore all of VVM should switch to only using `vyper-json` is another question to be discussed, but this enables AST construction with the fewest changes while we determine the best way forward.

### How to verify it

`pip install git+https://github.com/z80dev/vvm@pass-flags`

```python
import vvm

src = """
x: uint256

@external
def foo() -> uint256:
    return self.x
"""

vvm.compile_source(src, f='ast')
```

```
~/Developer/vvm pass-flags*
❯ python poc.py
{'<stdin>': {'ast': {'node_id': 0, 'body': [{'node_id': 1, 'is_public': False, 'is_immutable': False, 'src': '1:10:0', 'target': {'id': 'x', 'node_id': 2, 'ast_type': 'Name', 'col_offset': 0, 'end_col_offset': 1, 'end_lineno': 2, 'src': '1:1:0', 'lineno': 2}, 'ast_type': 'VariableDecl', 'col_offset': 0, 'end_col_offset': 10, 'value': None, 'is_transient': False, 'annotation': {'id': 'uint256', 'node_id': 4, 'ast_type': 'Name', 'col_offset': 3, 'end_col_offset': 10, 'end_lineno': 2, 'src': '4:7:0', 'lineno': 2}, 'end_lineno': 2, 'is_constant': False, 'lineno': 2}, {'node_id': 6, 'pos': None, 'body': [{'node_id': 8, 'ast_type': 'Return', 'col_offset': 4, 'value': {'node_id': 9, 'attr': 'x', 'ast_type': 'Attribute', 'col_offset': 11, 'value': {'id': 'self', 'node_id': 10, 'ast_type': 'Name', 'col_offset': 11, 'end_col_offset': 15, 'end_lineno': 5, 'src': '46:4:0', 'lineno': 5}, 'end_col_offset': 17, 'end_lineno': 5, 'src': '46:6:0', 'lineno': 5}, 'end_col_offset': 17, 'end_lineno': 5, 'src': '39:13:0', 'lineno': 5}], 'name': 'foo', 'doc_string': None, 'ast_type': 'FunctionDef', 'returns': {'id': 'uint256', 'node_id': 13, 'ast_type': 'Name', 'col_offset': 13, 'end_col_offset': 20, 'end_lineno': 4, 'src': '26:7:0', 'lineno': 4}, 'decorator_list': [], 'col_offset': 0, 'args': {'node_id': 7, 'defaults': [], 'ast_type': 'arguments', 'col_offset': 0, 'args': [], 'end_col_offset': 3, 'default': None, 'end_lineno': 4, 'src': '13:3:0', 'lineno': 4}, 'end_col_offset': 17, 'end_lineno': 5, 'src': '13:39:0', 'lineno': 4}], 'doc_string': None, 'name': '/var/folders/pw/hxmzlpdx18193c72f7pnf4xm0000gn/T/vyper-vjhn1vtf.vy', 'ast_type': 'Module', 'col_offset': 0, 'end_col_offset': 17, 'end_lineno': 5, 'src': '0:52:0', 'lineno': 1}}}
```

### Checklist

- [X] I have confirmed that my PR passes all linting checks
- [X] I have included test cases
- [X] I have updated the documentation (README.md)
- [X] I have added an entry to the changelog
