### PR TITLE
fix: reject npm-style version specifiers above v0.4.0

### DIFF
--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -57,5 +57,6 @@ def test_version_does_not_exist():
 def test_npm_version_for_04_release():
     with pytest.raises(UnexpectedVersionError) as excinfo:
         detect_vyper_version_from_source("# pragma version ^0.4.0")
+
     expected_msg = "Please use the pypi-style version specifier for vyper versions >= 0.4.0"
     assert str(excinfo.value) == msg

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -57,7 +57,5 @@ def test_version_does_not_exist():
 def test_npm_version_for_04_release():
     with pytest.raises(UnexpectedVersionError) as excinfo:
         detect_vyper_version_from_source("# pragma version ^0.4.0")
-    assert (
-        str(excinfo.value)
-        == "Please use the pypi-style version specifier for vyper versions >= 0.4.0"
-    )
+    expected_msg = "Please use the pypi-style version specifier for vyper versions >= 0.4.0"
+    assert str(excinfo.value) == msg

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -6,12 +6,6 @@ from vvm import detect_vyper_version_from_source
 from vvm.exceptions import UnexpectedVersionError
 from vvm.utils.versioning import _detect_version_specifier, _pick_vyper_version
 
-LAST_PER_MINOR = {
-    1: Version("0.1.0b17"),
-    2: Version("0.2.16"),
-    3: Version("0.3.10"),
-}
-
 
 def test_foo_vyper_version(foo_source, vyper_version):
     specifier = _detect_version_specifier(foo_source)
@@ -23,9 +17,10 @@ def test_foo_vyper_version(foo_source, vyper_version):
 @pytest.mark.parametrize(
     "version_str,decorator,pragma,expected_specifier,expected_version",
     [
-        ("^0.1.1", "public", "@version", "~=0.1", "latest"),
+        ("^0.2.0", "public", "@version", "~=0.2.0", "0.2.16"),
         ("~0.3.0", "external", "pragma version", "~=0.3.0", "0.3.10"),
         ("0.1.0b17", "public", "@version", "==0.1.0b17", "0.1.0b17"),
+        ("^0.1.0b16", "public", "@version", "~=0.1.0b16", "0.1.0b17"),
         (">=0.3.0-beta17", "external", "@version", ">=0.3.0-beta17", "latest"),
         ("0.4.0rc6", "external", "pragma version", "==0.4.0rc6", "0.4.0rc6"),
     ],

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -59,4 +59,4 @@ def test_npm_version_for_04_release():
         detect_vyper_version_from_source("# pragma version ^0.4.0")
 
     expected_msg = "Please use the pypi-style version specifier for vyper versions >= 0.4.0"
-    assert str(excinfo.value) == msg
+    assert str(excinfo.value) == expected_msg

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -52,3 +52,12 @@ def test_version_does_not_exist():
     with pytest.raises(UnexpectedVersionError) as excinfo:
         detect_vyper_version_from_source("# pragma version 2024.0.1")
     assert str(excinfo.value) == "No installable Vyper satisfies the specifier ==2024.0.1"
+
+
+def test_npm_version_for_04_release():
+    with pytest.raises(UnexpectedVersionError) as excinfo:
+        detect_vyper_version_from_source("# pragma version ^0.4.0")
+    assert (
+        str(excinfo.value)
+        == "Please use the pypi-style version specifier for vyper versions >= 0.4.0"
+    )

--- a/vvm/utils/versioning.py
+++ b/vvm/utils/versioning.py
@@ -34,12 +34,7 @@ def _detect_version_specifier(source_code: str) -> Specifier:
         if Version(version_str) >= Version("0.4.0"):
             error = "Please use the pypi-style version specifier for vyper versions >= 0.4.0"
             raise UnexpectedVersionError(error)
-
-        if specifier == "^" and not version_str.startswith("0."):
-            # Minor match, remove the patch from the version
-            # Note: not for 0.x versions, they should only match minor versions
-            version_str = ".".join(version_str.split(".")[:-1])
-
+        # for v0.x, both specifiers are equivalent
         specifier = "~="  # finds compatible versions
 
     if specifier == "":

--- a/vvm/utils/versioning.py
+++ b/vvm/utils/versioning.py
@@ -31,6 +31,10 @@ def _detect_version_specifier(source_code: str) -> Specifier:
 
     specifier, version_str = match.groups()
     if specifier in ("~", "^"):  # convert from npm-style to pypi-style
+        if Version(version_str) >= Version("0.4.0"):
+            error = "Please use the pypi-style version specifier for vyper versions >= 0.4.0"
+            raise UnexpectedVersionError(error)
+
         if specifier == "^" and not version_str.startswith("0."):
             # Minor match, remove the patch from the version
             # Note: not for 0.x versions, they should only match minor versions

--- a/vvm/utils/versioning.py
+++ b/vvm/utils/versioning.py
@@ -31,8 +31,11 @@ def _detect_version_specifier(source_code: str) -> Specifier:
 
     specifier, version_str = match.groups()
     if specifier in ("~", "^"):  # convert from npm-style to pypi-style
-        if specifier == "^":  # minor match, remove the patch from the version
+        if specifier == "^" and not version_str.startswith("0."):
+            # Minor match, remove the patch from the version
+            # Note: not for 0.x versions, they should only match minor versions
             version_str = ".".join(version_str.split(".")[:-1])
+
         specifier = "~="  # finds compatible versions
 
     if specifier == "":


### PR DESCRIPTION
### What I did
- FIxed issue when using the "^0.x.y" specifier
- According to [semver.npmjs.com](url) the caret should work differently for 0.x versions
![image](https://github.com/user-attachments/assets/66158e48-93e7-421f-b397-817c17973e35)
- For example:
![image](https://github.com/user-attachments/assets/93bd82ba-c5a2-4a7e-907e-000e541cad4c)

fix by rejecting npm-style specifiers above v0.4.0

### How to verify it
- Version specifier ^0.3.x should not accept vyper 0.4.0

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
