### PR TITLE
fix `combined_json` for versions >0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/vyperlang/vvm/)
 ### Changed
-- Update contact information in `CONTRIBUTING.md`
+- Update contact information in `CONTRIBUTING.md` ([#17](https://github.com/vyperlang/vvm/pull/17), [#18](https://github.com/vyperlang/vvm/pull/18))
 - Update dependencies. Minimum python version is now 3.8 ([#22](https://github.com/vyperlang/vvm/pull/22))
 - Add `output_format` argument to `compile_source` and `compile_files` ([#21](https://github.com/vyperlang/vvm/pull/21))
 - New public function `detect_vyper_version_from_source` ([#23](https://github.com/vyperlang/vvm/pull/23))
+- Fix `combine_json` for versions `>0.3.10` ([#29](https://github.com/vyperlang/vvm/pull/29))
 
 ## [0.1.0](https://github.com/vyperlang/vvm/tree/v0.1.0) - 2020-10-07
 ### Added

--- a/tests/test_compile_source.py
+++ b/tests/test_compile_source.py
@@ -9,6 +9,7 @@ def test_compile_source(foo_source, vyper_version):
         pytest.skip("vyper 0.4.0b1 to 0.4.0b5 have a bug with combined_json")
     output = vvm.compile_source(foo_source)
     assert "<stdin>" in output
+    assert "bytecode" in output["<stdin>"]
 
 
 def test_compile_files(foo_path, vyper_version):

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -76,6 +76,9 @@ def compile_source(
         )
 
     if output_format in ("combined_json", None):
+        # If someone was to compile a file named `version` (without extension),
+        # the json would contain a single entry that we would pop here.
+        # it is assumed that developers are not compiling files named `version`.
         compiler_data.pop("version", None)
         return {"<stdin>": list(compiler_data.values())[0]}
     return compiler_data

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -76,6 +76,8 @@ def compile_source(
         )
 
     if output_format in ("combined_json", None):
+        if "version" in compiler_data:
+            compiler_data.pop("version")
         return {"<stdin>": list(compiler_data.values())[0]}
     return compiler_data
 

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -78,6 +78,8 @@ def compile_source(
     if output_format in ("combined_json", None):
         # Pop the version as it might be the first key in the dictionary
         # We assumed the source file is not named `version` (without extension)
+        # vyper 0.4.0 and up puts version at the front of the dict, which breaks
+        # the `list(compiler_data.values())[0]` on the next line, so remove it.
         compiler_data.pop("version", None)
         return {"<stdin>": list(compiler_data.values())[0]}
     return compiler_data

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -76,8 +76,7 @@ def compile_source(
         )
 
     if output_format in ("combined_json", None):
-        if "version" in compiler_data:
-            compiler_data.pop("version")
+        compiler_data.pop("version", None)
         return {"<stdin>": list(compiler_data.values())[0]}
     return compiler_data
 

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -76,9 +76,8 @@ def compile_source(
         )
 
     if output_format in ("combined_json", None):
-        # If someone was to compile a file named `version` (without extension),
-        # the json would contain a single entry that we would pop here.
-        # it is assumed that developers are not compiling files named `version`.
+        # Pop the version as it might be the first key in the dictionary
+        # We assumed the source file is not named `version` (without extension)
         compiler_data.pop("version", None)
         return {"<stdin>": list(compiler_data.values())[0]}
     return compiler_data

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -76,10 +76,9 @@ def compile_source(
         )
 
     if output_format in ("combined_json", None):
-        # Pop the version as it might be the first key in the dictionary
-        # We assumed the source file is not named `version` (without extension)
-        # vyper 0.4.0 and up puts version at the front of the dict, which breaks
+        # Vyper 0.4.0 and up puts version at the front of the dict, which breaks
         # the `list(compiler_data.values())[0]` on the next line, so remove it.
+        # Assumes the source file is not named `version` (without extension)
         compiler_data.pop("version", None)
         return {"<stdin>": list(compiler_data.values())[0]}
     return compiler_data


### PR DESCRIPTION
### What I did

Fixed the `combined_json` output for versions `0.4.x`
Fixes #28 
### How I did it

pop from the dict `version` as it would be before the contract's data.
 
### How to verify it

```python
import vvm
print(vvm.compile_source("# pragma version 0.4.0", vyper_version="0.4.0"))
```
would return before:
```
{'<stdin>': '0.4.0'}
```
and now:
```
{'<stdin>': {'bytecode': '0x61000361000f6000396100036000f35f5ffd84038000a1657679706572830004000011', 'bytecode_runtime': '0x5f5ffd', 'blueprint_bytecode': '0x6100263d81600a3d39f3fe710061000361000f6000396100036000f35f5ffd84038000a1657679706572830004000011', 'abi': [], 'layout': {}, 'source_map': {'breakpoints': [], 'error_map': {'17': 'fallback function'}, 'pc_breakpoints': [], 'pc_jump_map': {'0': '-', '15': '-'}, 'pc_pos_map_compressed': '0:22:0:-;-1:-1:-1;-1:-1:-1;-1:-1:-1;-1:-1:-1;-1:-1:-1;-1:-1:-1;-1:-1:-1;-1:-1:-1;-1:-1:-1;-1:-1:-1;-1:-1:-1;-1:-1:-1;-1:-1:-1;-1:-1:-1;-1:-1:-1:-;-1:-1:-1;-1:-1:-1', 'pc_pos_map': {'0': [1, 0, 1, 22]}, 'pc_ast_map': {'0': [0, 0]}, 'pc_ast_map_item_keys': ['source_id', 'node_id']}, 'source_map_runtime': {'breakpoints': [], 'error_map': {'2': 'fallback function'}, 'pc_breakpoints': [], 'pc_jump_map': {'0': '-'}, 'pc_pos_map_compressed': '0:22:0:-;-1:-1:-1;-1:-1:-1', 'pc_pos_map': {'0': [1, 0, 1, 22]}, 'pc_ast_map': {'0': [0, 0]}, 'pc_ast_map_item_keys': ['source_id', 'node_id']}, 'method_identifiers': {}, 'userdoc': {}, 'devdoc': {}}}
```

### Checklist

- [X] I have confirmed that my PR passes all linting checks
- [X] I have included test cases
- [X] I have updated the documentation (README.md)
- [X] I have added an entry to the changelog
