### PR TITLE
fix: relax version detection checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update dependencies. Minimum python version is now 3.8 ([#22](https://github.com/vyperlang/vvm/pull/22))
 - Add `output_format` argument to `compile_source` and `compile_files` ([#21](https://github.com/vyperlang/vvm/pull/21))
 - New public function `detect_vyper_version_from_source` ([#23](https://github.com/vyperlang/vvm/pull/23))
+- Relax version detection checks ([#30](https://github.com/vyperlang/vvm/pull/30))
 
 ## [0.1.0](https://github.com/vyperlang/vvm/tree/v0.1.0) - 2020-10-07
 ### Added

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -4,7 +4,7 @@ from packaging.version import Version
 
 from vvm import detect_vyper_version_from_source
 from vvm.exceptions import UnexpectedVersionError
-from vvm.utils.versioning import detect_version_specifier_set, _pick_vyper_version
+from vvm.utils.versioning import _pick_vyper_version, detect_version_specifier_set
 
 
 def test_foo_vyper_version(foo_source, vyper_version):

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -18,7 +18,6 @@ def test_foo_vyper_version(foo_source, vyper_version):
     "version_str,decorator,pragma,expected_specifier_set,expected_version",
     [
         ("^0.2.0", "public", "@version", "~=0.2.0", "0.2.16"),
-        ("~0.3.0", "external", "pragma version", "~=0.3.0", "0.3.10"),
         ("^0.4.0", "external", "pragma version", "~=0.4.0", "0.4.0"),
         (">=0.3.10, <0.4.0", "external", "pragma version", ">=0.3.10, <0.4.0", "0.3.10"),
         ("0.1.0b17", "public", "@version", "==0.1.0b17", "0.1.0b17"),

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -4,11 +4,11 @@ from packaging.version import Version
 
 from vvm import detect_vyper_version_from_source
 from vvm.exceptions import UnexpectedVersionError
-from vvm.utils.versioning import _detect_version_specifier, _pick_vyper_version
+from vvm.utils.versioning import detect_version_specifier_set, _pick_vyper_version
 
 
 def test_foo_vyper_version(foo_source, vyper_version):
-    specifier = _detect_version_specifier(foo_source)
+    specifier = detect_version_specifier_set(foo_source)
     assert str(specifier) == f"=={vyper_version}"
     assert vyper_version.major == 0
     assert _pick_vyper_version(specifier) == vyper_version
@@ -37,7 +37,7 @@ def test_vyper_version(
 def foo() -> int128:
     return 42
     """
-    detected = _detect_version_specifier(source)
+    detected = detect_version_specifier_set(source)
     assert detected == SpecifierSet(expected_specifier_set)
     if expected_version == "latest":
         expected_version = str(latest_version)

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -22,7 +22,7 @@ def test_foo_vyper_version(foo_source, vyper_version):
         ("^0.4.0", "external", "pragma version", "~=0.4.0", "0.4.0"),
         ("^0.1.0b16", "public", "@version", "~=0.1.0b16", "0.1.0b17"),
         # indented comment is supported
-        ("    0.4.0", "external", "pragma version", "==0.4.0", "0.4.0"),
+        ("0.4.0", "external", "    pragma version", "==0.4.0", "0.4.0"),
         # pep440 >= and < are preserved
         (">=0.3.10, <0.4.0", "external", "pragma version", ">=0.3.10, <0.4.0", "0.3.10"),
         # beta and release candidate are supported
@@ -59,7 +59,7 @@ def foo() -> int128:
     ],
 )
 def test_unsported_vyper_version(version_str):
-    # npm's complex ranges are not supported although old vyper version can handle them
+    # npm's complex ranges are not supported although old vyper versions can handle them
     source = f"""
 # @version {version_str}
     """

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -28,7 +28,7 @@ def test_foo_vyper_version(foo_source, vyper_version):
         # beta and release candidate are supported
         ("0.1.0b17", "public", "@version", "==0.1.0b17", "0.1.0b17"),
         ("0.4.0rc6", "external", "pragma version", "==0.4.0rc6", "0.4.0rc6"),
-        (">=0.3.0-beta17", "external", "@version", ">=0.3.0-beta17", "latest"),
+        (">=0.3.0-beta17", "external", "@version", ">=0.3.0b17", "latest"),
     ],
 )
 def test_vyper_version(

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -135,7 +135,6 @@ def _compile(
     output_format: Optional[str],
     **kwargs: Any,
 ) -> Any:
-
     if vyper_binary is None:
         vyper_binary = get_executable(vyper_version)
     if output_format is None:

--- a/vvm/utils/versioning.py
+++ b/vvm/utils/versioning.py
@@ -2,16 +2,15 @@ import itertools
 import re
 from typing import Any, Optional
 
-from packaging.specifiers import Specifier
+from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from vvm.exceptions import UnexpectedVersionError
 from vvm.install import get_installable_vyper_versions, get_installed_vyper_versions
 
-_VERSION_RE = re.compile(r"\s*#\s*(?:pragma\s+|@)version\s+([=><^~]*)(\d+\.\d+\.\d+\S*)")
+_VERSION_RE = re.compile(r"^(?:#\s*(?:@version|pragma\s+version)\s+(.*))", re.MULTILINE)
 
-
-def _detect_version_specifier(source_code: str) -> Optional[Specifier]:
+def _detect_version_specifier(source_code: str) -> Optional[SpecifierSet]:
     """
     Detect the version given by the pragma version in the source code.
 
@@ -22,42 +21,40 @@ def _detect_version_specifier(source_code: str) -> Optional[Specifier]:
 
     Returns
     -------
-    str
-        vyper version specifier, or None if none could be detected.
+    Optional[SpecifierSet]
+        vyper version specifier set, or None if none could be detected.
     """
-    match = _VERSION_RE.search(source_code)
-    if match is None:
+    version_str = _VERSION_RE.findall(source_code)
+    if not version_str:
         return None
+    
+    version_str = version_str[0]
+    
+    # X.Y.Z or vX.Y.Z => ==X.Y.Z, ==vX.Y.Z
+    if re.match("[v0-9]", version_str):
+        version_str = "==" + version_str
+    # convert npm to pep440
+    version_str = re.sub("^\\^", "~=", version_str)
+    version_str = re.sub("^~(?!\\=)", "~=", version_str)
 
-    specifier, version_str = match.groups()
-    if specifier in ("~", "^"):  # convert from npm-style to pypi-style
-        if Version(version_str) >= Version("0.4.0"):
-            error = "Please use the pypi-style version specifier "
-            error += f"for vyper versions >= 0.4.0 (hint: try ~={version_str})"
-            raise UnexpectedVersionError(error)
-        # for v0.x, both specifiers are equivalent
-        specifier = "~="  # finds compatible versions
-
-    if specifier == "":
-        specifier = "=="
-    return Specifier(specifier + version_str)
+    return SpecifierSet(version_str)
 
 
 def _pick_vyper_version(
-    specifier: Specifier,
+    specifier_set: SpecifierSet,
     prereleases: Optional[bool] = None,
     check_installed: bool = True,
     check_installable: bool = True,
 ) -> Version:
     """
-    Pick the latest vyper version that is installed and satisfies the given specifier.
-    If None of the installed versions satisfy the specifier, pick the latest installable
+    Pick the latest vyper version that is installed and satisfies the given specifier set.
+    If None of the installed versions satisfy the specifier set, pick the latest installable
     version.
 
     Arguments
     ---------
-    specifier : Specifier
-        Specifier to pick a version for.
+    specifier_set : SpecifierSet
+        Specifier set to pick a version for.
     prereleases : bool, optional
         Whether to allow prereleases in the returned iterator. If set to
         ``None`` (the default), it will be intelligently decide whether to allow
@@ -71,14 +68,14 @@ def _pick_vyper_version(
     Returns
     -------
     Version
-        Vyper version that satisfies the specifier, or None if no version satisfies the specifier.
+        Vyper version that satisfies the specifier set, or None if no version satisfies the specifier set.
     """
     versions = itertools.chain(
         get_installed_vyper_versions() if check_installed else [],
         get_installable_vyper_versions() if check_installable else [],
     )
-    if (ret := next(specifier.filter(versions, prereleases), None)) is None:
-        raise UnexpectedVersionError(f"No installable Vyper satisfies the specifier {specifier}")
+    if (ret := next(specifier_set.filter(versions, prereleases), None)) is None:
+        raise UnexpectedVersionError(f"No installable Vyper satisfies the specifier {specifier_set}")
     return ret
 
 
@@ -98,7 +95,7 @@ def detect_vyper_version_from_source(source_code: str, **kwargs: Any) -> Optiona
     Optional[Version]
         vyper version, or None if no version could be detected.
     """
-    specifier = _detect_version_specifier(source_code)
-    if specifier is None:
+    specifier_set = _detect_version_specifier(source_code)
+    if specifier_set is None:
         return None
-    return _pick_vyper_version(specifier, **kwargs)
+    return _pick_vyper_version(specifier_set, **kwargs)

--- a/vvm/utils/versioning.py
+++ b/vvm/utils/versioning.py
@@ -8,6 +8,11 @@ from packaging.version import Version
 from vvm.exceptions import UnexpectedVersionError
 from vvm.install import get_installable_vyper_versions, get_installed_vyper_versions
 
+# Find the first occurence of version specifier in the source code.
+# allow for indented comment (as the compiler allows it (as of 0.4.0)).
+# might have false positive if a triple quoted string contains a line
+# that looks like a version specifier and is before the actual version
+# specifier in the code, but this is accepted as it is an unlikely edge case.
 _VERSION_RE = re.compile(r"^\s*(?:#\s*(?:@version|pragma\s+version)\s+(.*))", re.MULTILINE)
 
 

--- a/vvm/utils/versioning.py
+++ b/vvm/utils/versioning.py
@@ -35,9 +35,10 @@ def detect_version_specifier_set(source_code: str) -> Optional[SpecifierSet]:
     if re.match("[v0-9]", version_str):
         version_str = "==" + version_str
     # adapted from vyper/ast/pre_parse.py at commit c32b9b4c6f0d8
-    # convert npm to pep440
+    # partially convert npm to pep440
+    # - <0.4.0 contracts with complex npm version range might fail
+    # - in versions >=1.0.0, the below conversion will be invalid
     version_str = re.sub("^\\^", "~=", version_str)
-    version_str = re.sub("^~(?!\\=)", "~=", version_str)
 
     return SpecifierSet(version_str)
 

--- a/vvm/utils/versioning.py
+++ b/vvm/utils/versioning.py
@@ -34,6 +34,7 @@ def detect_version_specifier_set(source_code: str) -> Optional[SpecifierSet]:
     # X.Y.Z or vX.Y.Z => ==X.Y.Z, ==vX.Y.Z
     if re.match("[v0-9]", version_str):
         version_str = "==" + version_str
+    # adapted from vyper/ast/pre_parse.py at commit c32b9b4c6f0d8
     # convert npm to pep440
     version_str = re.sub("^\\^", "~=", version_str)
     version_str = re.sub("^~(?!\\=)", "~=", version_str)

--- a/vvm/utils/versioning.py
+++ b/vvm/utils/versioning.py
@@ -11,14 +11,14 @@ from vvm.install import get_installable_vyper_versions, get_installed_vyper_vers
 _VERSION_RE = re.compile(r"^(?:#\s*(?:@version|pragma\s+version)\s+(.*))", re.MULTILINE)
 
 
-def _detect_version_specifier(source_code: str) -> Optional[SpecifierSet]:
+def detect_version_specifier_set(source_code: str) -> Optional[SpecifierSet]:
     """
-    Detect the version given by the pragma version in the source code.
+    Detect the specifier set given by the pragma version in the source code.
 
     Arguments
     ---------
     source_code : str
-        Source code to detect the version from.
+        Source code to detect the specifier set from.
 
     Returns
     -------
@@ -98,7 +98,7 @@ def detect_vyper_version_from_source(source_code: str, **kwargs: Any) -> Optiona
     Optional[Version]
         vyper version, or None if no version could be detected.
     """
-    specifier_set = _detect_version_specifier(source_code)
+    specifier_set = detect_version_specifier_set(source_code)
     if specifier_set is None:
         return None
     return _pick_vyper_version(specifier_set, **kwargs)

--- a/vvm/utils/versioning.py
+++ b/vvm/utils/versioning.py
@@ -25,11 +25,11 @@ def _detect_version_specifier(source_code: str) -> Optional[SpecifierSet]:
     Optional[SpecifierSet]
         vyper version specifier set, or None if none could be detected.
     """
-    version_str = _VERSION_RE.findall(source_code)
-    if not version_str:
+    match = _VERSION_RE.findall(source_code)
+    if not match:
         return None
 
-    version_str = version_str[0]
+    version_str = match[0]
 
     # X.Y.Z or vX.Y.Z => ==X.Y.Z, ==vX.Y.Z
     if re.match("[v0-9]", version_str):

--- a/vvm/utils/versioning.py
+++ b/vvm/utils/versioning.py
@@ -10,6 +10,7 @@ from vvm.install import get_installable_vyper_versions, get_installed_vyper_vers
 
 _VERSION_RE = re.compile(r"^(?:#\s*(?:@version|pragma\s+version)\s+(.*))", re.MULTILINE)
 
+
 def _detect_version_specifier(source_code: str) -> Optional[SpecifierSet]:
     """
     Detect the version given by the pragma version in the source code.
@@ -27,9 +28,9 @@ def _detect_version_specifier(source_code: str) -> Optional[SpecifierSet]:
     version_str = _VERSION_RE.findall(source_code)
     if not version_str:
         return None
-    
+
     version_str = version_str[0]
-    
+
     # X.Y.Z or vX.Y.Z => ==X.Y.Z, ==vX.Y.Z
     if re.match("[v0-9]", version_str):
         version_str = "==" + version_str
@@ -68,14 +69,16 @@ def _pick_vyper_version(
     Returns
     -------
     Version
-        Vyper version that satisfies the specifier set, or None if no version satisfies the specifier set.
+        Vyper version that satisfies the specifier set, or None if no version satisfies the set.
     """
     versions = itertools.chain(
         get_installed_vyper_versions() if check_installed else [],
         get_installable_vyper_versions() if check_installable else [],
     )
     if (ret := next(specifier_set.filter(versions, prereleases), None)) is None:
-        raise UnexpectedVersionError(f"No installable Vyper satisfies the specifier {specifier_set}")
+        raise UnexpectedVersionError(
+            f"No installable Vyper satisfies the specifier {specifier_set}"
+        )
     return ret
 
 

--- a/vvm/utils/versioning.py
+++ b/vvm/utils/versioning.py
@@ -25,11 +25,11 @@ def detect_version_specifier_set(source_code: str) -> Optional[SpecifierSet]:
     Optional[SpecifierSet]
         vyper version specifier set, or None if none could be detected.
     """
-    match = _VERSION_RE.findall(source_code)
-    if not match:
+    match = _VERSION_RE.search(source_code)
+    if match is None:
         return None
 
-    version_str = match[0]
+    version_str = match.group(1)
 
     # X.Y.Z or vX.Y.Z => ==X.Y.Z, ==vX.Y.Z
     if re.match("[v0-9]", version_str):

--- a/vvm/utils/versioning.py
+++ b/vvm/utils/versioning.py
@@ -8,7 +8,7 @@ from packaging.version import Version
 from vvm.exceptions import UnexpectedVersionError
 from vvm.install import get_installable_vyper_versions, get_installed_vyper_versions
 
-_VERSION_RE = re.compile(r"^(?:#\s*(?:@version|pragma\s+version)\s+(.*))", re.MULTILINE)
+_VERSION_RE = re.compile(r"^\s*(?:#\s*(?:@version|pragma\s+version)\s+(.*))", re.MULTILINE)
 
 
 def detect_version_specifier_set(source_code: str) -> Optional[SpecifierSet]:


### PR DESCRIPTION
### What I did

vvm should never perform checks more restrictive than the compiler itself. As opposed, if checks are not strict enough, the compiler will anyway fail later.

Hence, this PR relaxes the following version detection checks:

1. Allow for multiple specifiers (specifier set); for example `>=0.3.10, <0.4.0`
2. Allow for using npm notation even for recent versions such as `^0.4.0` as it get converted to pep440 even in recent versions of the compiler.
3. Allow for using npm notation such as `~0.3.1` as older versions of the compiler accept them.

Additionally, this PR exposes `detect_version_specifier_set` such that `titanoboa` can check if the installed vyper version is in the set before calling `detect_vyper_version_from_source`.

### How I did it

Updated `_detect_version_specifier` to match Vyper's own pragma validation.

### How to verify it

See updated test.

### Checklist

- [X] I have confirmed that my PR passes all linting checks
- [X] I have included test cases
- [X] I have updated the documentation (README.md)
- [X] I have added an entry to the changelog
