### PR TITLE
feat: add flag to `install_vyper()` for skipping validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,32 @@ cd vvm
 python3 setup.py install
 ```
 
+## Quickstart
+
+Use `vvm` to install versions of Vyper:
+
+```python
+from vvm import install_vyper
+
+install_vyper(version="0.4.0")
+```
+
+**Note**: On macOS with the Apple chips, installing some versions of Vyper may fail if you have not first run this
+command:
+
+```python
+softwareupdate --install-rosetta
+```
+
+To install Vyper without validating the binary (which is useful in the case where you did first run the command above
+but will later or are managing versions of Vyper without running them), you can set `skip_validation=False`.
+
+```python
+from vvm import install_vyper
+
+install_vyper(version="0.4.0", validate=False)
+```
+
 ## Testing
 
 `vvm` is tested on Linux, OSX and Windows with Vyper versions `>=0.1.0-beta.16`.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,11 @@ install_vyper(version="0.4.0")
 **Note**: On macOS with the Apple chips, installing some versions of Vyper may fail if you have not first run this
 command:
 
-```python
+```bash
 softwareupdate --install-rosetta
 ```
 
-To install Vyper without validating the binary (which is useful in the case where you did first run the command above
-but will later or are managing versions of Vyper without running them), you can set `skip_validation=False`.
+To install Vyper without validating the binary (useful for debugging), you can set `validate=False`.
 
 ```python
 from vvm import install_vyper

--- a/vvm/install.py
+++ b/vvm/install.py
@@ -62,7 +62,7 @@ def get_vvm_install_folder(vvm_binary_path: Union[Path, str] = None) -> Path:
     Returns
     -------
     Path
-        Subdirectory where `vyper` binaries are are saved.
+        Subdirectory where `vyper` binaries are saved.
     """
     if os.getenv(VVM_BINARY_PATH_VARIABLE):
         return Path(os.environ[VVM_BINARY_PATH_VARIABLE])

--- a/vvm/install.py
+++ b/vvm/install.py
@@ -238,6 +238,9 @@ def install_vyper(
         User-defined path, used to override the default installation directory.
     validate : bool
         Set to False to skip validating the downloaded binary. Defaults to True.
+        Useful for when debugging why a binary fails to run on your OS (may need
+        additional setup) or if managing binaries without needing to run them
+        (such as a mirror).
 
     Returns
     -------

--- a/vvm/install.py
+++ b/vvm/install.py
@@ -7,7 +7,6 @@ from base64 import b64encode
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
-import requests
 from packaging.version import Version
 
 from vvm import wrapper

--- a/vvm/install.py
+++ b/vvm/install.py
@@ -222,6 +222,7 @@ def install_vyper(
     show_progress: bool = False,
     vvm_binary_path: Union[Path, str] = None,
     headers: Dict = None,
+    validate: bool = True,
 ) -> Version:
     """
     Download and install a precompiled version of `vyper`.
@@ -235,6 +236,8 @@ def install_vyper(
         the `tqdm` package.
     vvm_binary_path : Path | str, optional
         User-defined path, used to override the default installation directory.
+    validate : bool
+        Set to False to skip validating the downloaded binary. Defaults to True.
 
     Returns
     -------
@@ -276,7 +279,8 @@ def install_vyper(
         if os_name != "windows":
             install_path.chmod(install_path.stat().st_mode | stat.S_IEXEC)
 
-        _validate_installation(version, vvm_binary_path)
+        if validate:
+            _validate_installation(version, vvm_binary_path)
 
     return version
 


### PR DESCRIPTION
### What I did

Related issue: #32 

### How I did it

Add a bool kwarg and honor it.

### How to verify it

This is on an arm64 device (mac):

```
In [2]: vvm.install.install_vyper("0.3.7", validate=False)
Out[2]: <Version('0.3.7')>
```


obviously it still does not work but at least I have it, which helps me

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
