### PR TITLE
feat: allow multiple paths to `.compile_files()`

### DIFF
--- a/tests/test_compile_source.py
+++ b/tests/test_compile_source.py
@@ -1,5 +1,5 @@
+import tempfile
 from pathlib import Path
-from site import getsitepackages
 
 import pytest
 from packaging.version import Version
@@ -25,7 +25,10 @@ def test_compile_files(foo_path, vyper_version):
 def test_compile_files_search_paths(foo_path, vyper_version):
     if Version("0.4.0b1") <= vyper_version <= Version("0.4.0b5"):
         pytest.skip("vyper 0.4.0b1 to 0.4.0b5 have a bug with combined_json")
-    output = vvm.compile_files([foo_path], search_paths=[Path.cwd(), *getsitepackages()])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output = vvm.compile_files([foo_path], search_paths=[Path.cwd(), tmpdir])
+
     assert foo_path.as_posix() in output
 
 

--- a/tests/test_compile_source.py
+++ b/tests/test_compile_source.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from packaging.version import Version
 
@@ -19,10 +21,10 @@ def test_compile_files(foo_path, vyper_version):
     assert foo_path.as_posix() in output
 
 
-def test_compile_files_multiple_p(foo_path, vyper_version):
+def test_compile_files_search_paths(foo_path, vyper_version):
     if Version("0.4.0b1") <= vyper_version <= Version("0.4.0b5"):
         pytest.skip("vyper 0.4.0b1 to 0.4.0b5 have a bug with combined_json")
-    output = vvm.compile_files([foo_path], base_path=[Path.cwd(), *getsitepackages()])
+    output = vvm.compile_files([foo_path], search_paths=[Path.cwd(), *getsitepackages()])
     assert foo_path.as_posix() in output
 
 

--- a/tests/test_compile_source.py
+++ b/tests/test_compile_source.py
@@ -19,6 +19,13 @@ def test_compile_files(foo_path, vyper_version):
     assert foo_path.as_posix() in output
 
 
+def test_compile_files_multiple_p(foo_path, vyper_version):
+    if Version("0.4.0b1") <= vyper_version <= Version("0.4.0b5"):
+        pytest.skip("vyper 0.4.0b1 to 0.4.0b5 have a bug with combined_json")
+    output = vvm.compile_files([foo_path], base_path=[Path.cwd(), *getsitepackages()])
+    assert foo_path.as_posix() in output
+
+
 def test_compile_standard(input_json, foo_source):
     input_json["sources"] = {"contracts/Foo.vy": {"content": foo_source}}
     result = vvm.compile_standard(input_json)

--- a/tests/test_compile_source.py
+++ b/tests/test_compile_source.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from site import getsitepackages
 
 import pytest
 from packaging.version import Version

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -86,7 +86,7 @@ def compile_source(
 
 def compile_files(
     source_files: Union[List, Path, str],
-    base_path: Union[Path, str] = None,
+    base_path: Union[Path, str, List[Union[Path, str]]] = None,
     evm_version: str = None,
     vyper_binary: Union[str, Path] = None,
     vyper_version: Union[str, Version, None] = None,
@@ -102,7 +102,7 @@ def compile_files(
     ---------
     source_files: List
         Path or list of paths of Vyper source files to be compiled.
-    base_path : Path | str, optional
+    base_path : Path | str | List, optional
         Use the given path as the root of the source tree instead of the root
         of the filesystem.
     evm_version: str, optional
@@ -133,7 +133,7 @@ def compile_files(
 
 
 def _compile(
-    base_path: Union[str, Path, None],
+    base_path: Union[str, Path, None, List[Union[str, Path]]],
     vyper_binary: Union[str, Path, None],
     vyper_version: Union[str, Version, None],
     output_format: Optional[str],
@@ -145,7 +145,7 @@ def _compile(
         output_format = "combined_json"
 
     stdoutdata, stderrdata, command, proc = wrapper.vyper_wrapper(
-        vyper_binary=vyper_binary, f=output_format, p=base_path, **kwargs
+        vyper_binary=vyper_binary, f=output_format, paths=base_path, **kwargs
     )
 
     if output_format in ("combined_json", "standard_json", "metadata"):

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -153,7 +153,7 @@ def _compile(
     if base_path is not None and search_paths is not None:
         raise ValueError("Cannot specify both 'base_path' and 'search_paths'.")
 
-    paths = [base_path] if base_path is not None else search_paths
+    paths = search_paths if base_path is None else [base_path]
     stdoutdata, stderrdata, command, proc = wrapper.vyper_wrapper(
         vyper_binary=vyper_binary, f=output_format, paths=paths, **kwargs
     )

--- a/vvm/main.py
+++ b/vvm/main.py
@@ -86,11 +86,12 @@ def compile_source(
 
 def compile_files(
     source_files: Union[List, Path, str],
-    base_path: Union[Path, str, List[Union[Path, str]]] = None,
+    base_path: Optional[Union[Path, str]] = None,
     evm_version: str = None,
     vyper_binary: Union[str, Path] = None,
     vyper_version: Union[str, Version, None] = None,
     output_format: str = None,
+    search_paths: Optional[List[Union[Path, str]]] = None,
 ) -> Any:
     """
     Compile one or more Vyper source files.
@@ -102,7 +103,7 @@ def compile_files(
     ---------
     source_files: List
         Path or list of paths of Vyper source files to be compiled.
-    base_path : Path | str | List, optional
+    base_path : Path | str, optional
         Use the given path as the root of the source tree instead of the root
         of the filesystem.
     evm_version: str, optional
@@ -115,6 +116,9 @@ def compile_files(
         Ignored if `vyper_binary` is also given.
     output_format: str, optional
         Output format of the compiler. See `vyper --help` for more information.
+    search_paths: List[str | Path], optional
+        Additional search paths. Only applicable for Vyper 0.4. Cannot use with
+        `base_path` argument.
 
     Returns
     -------
@@ -129,14 +133,16 @@ def compile_files(
         base_path=base_path,
         evm_version=evm_version,
         output_format=output_format,
+        search_paths=search_paths,
     )
 
 
 def _compile(
-    base_path: Union[str, Path, None, List[Union[str, Path]]],
+    base_path: Union[str, Path, None],
     vyper_binary: Union[str, Path, None],
     vyper_version: Union[str, Version, None],
     output_format: Optional[str],
+    search_paths: Optional[List[Union[Path, str]]] = None,
     **kwargs: Any,
 ) -> Any:
     if vyper_binary is None:
@@ -144,8 +150,12 @@ def _compile(
     if output_format is None:
         output_format = "combined_json"
 
+    if base_path is not None and search_paths is not None:
+        raise ValueError("Cannot specify both 'base_path' and 'search_paths'.")
+
+    paths = [base_path] if base_path is not None else search_paths
     stdoutdata, stderrdata, command, proc = wrapper.vyper_wrapper(
-        vyper_binary=vyper_binary, f=output_format, paths=base_path, **kwargs
+        vyper_binary=vyper_binary, f=output_format, paths=paths, **kwargs
     )
 
     if output_format in ("combined_json", "standard_json", "metadata"):

--- a/vvm/wrapper.py
+++ b/vvm/wrapper.py
@@ -1,6 +1,6 @@
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from packaging.version import Version
 
@@ -40,6 +40,7 @@ def vyper_wrapper(
     stdin: str = None,
     source_files: Union[List, Path, str] = None,
     success_return_code: int = 0,
+    paths: Optional[Union[List[Union[Path, str]], Path, str]] = None,
     **kwargs: Any,
 ) -> Tuple[str, str, List, subprocess.Popen]:
     """
@@ -94,6 +95,13 @@ def vyper_wrapper(
             command.append(_to_string("source_files", source_files))
         else:
             command.extend([_to_string("source_files", i) for i in source_files])
+
+    if paths:
+        if isinstance(paths, list):
+            for path in paths:
+                command.extend(("-p", f"{path}"))
+        else:
+            command.extend(("-p", f"{paths}"))
 
     for key, value in kwargs.items():
         if value is None or value is False:

--- a/vvm/wrapper.py
+++ b/vvm/wrapper.py
@@ -40,7 +40,7 @@ def vyper_wrapper(
     stdin: str = None,
     source_files: Union[List, Path, str] = None,
     success_return_code: int = 0,
-    paths: Optional[Union[List[Union[Path, str]], Path, str]] = None,
+    paths: Optional[List[Union[Path, str]]] = None,
     **kwargs: Any,
 ) -> Tuple[str, str, List, subprocess.Popen]:
     """
@@ -97,11 +97,8 @@ def vyper_wrapper(
             command.extend([_to_string("source_files", i) for i in source_files])
 
     if paths:
-        if isinstance(paths, (list, tuple)):
-            for path in paths:
-                command.extend(("-p", f"{path}"))
-        else:
-            command.extend(("-p", f"{paths}"))
+        for path in paths:
+            command.extend(("-p", f"{path}"))
 
     for key, value in kwargs.items():
         if value is None or value is False:

--- a/vvm/wrapper.py
+++ b/vvm/wrapper.py
@@ -96,7 +96,7 @@ def vyper_wrapper(
         else:
             command.extend([_to_string("source_files", i) for i in source_files])
 
-    if paths:
+    if paths is not None:
         for path in paths:
             command.extend(("-p", f"{path}"))
 

--- a/vvm/wrapper.py
+++ b/vvm/wrapper.py
@@ -97,7 +97,7 @@ def vyper_wrapper(
             command.extend([_to_string("source_files", i) for i in source_files])
 
     if paths:
-        if isinstance(paths, list):
+        if isinstance(paths, (list, tuple)):
             for path in paths:
                 command.extend(("-p", f"{path}"))
         else:


### PR DESCRIPTION
### What I did

Allows passing in mutliple paths to `.compile_files()`. This allows us to pass in site-packages for using snekmate, otherwise I can't get it to work for some reason.

### How I did it

new `paths` kwarg to the wrapper and use that instead of `-p` in the `_compile()` method.

### How to verify it

can compile a contract with snekmate now

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
