### PR TITLE
feat: publish types with the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.md
+include vvm/py.typed
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/tests/test_compile_source.py
+++ b/tests/test_compile_source.py
@@ -19,13 +19,6 @@ def test_compile_files(foo_path, vyper_version):
     assert foo_path.as_posix() in output
 
 
-def test_compile_files_multiple_p(foo_path, vyper_version):
-    if Version("0.4.0b1") <= vyper_version <= Version("0.4.0b5"):
-        pytest.skip("vyper 0.4.0b1 to 0.4.0b5 have a bug with combined_json")
-    output = vvm.compile_files([foo_path], base_path=[Path.cwd(), *getsitepackages()])
-    assert foo_path.as_posix() in output
-
-
 def test_compile_standard(input_json, foo_source):
     input_json["sources"] = {"contracts/Foo.vy": {"content": foo_source}}
     result = vvm.compile_standard(input_json)

--- a/tests/test_compile_source.py
+++ b/tests/test_compile_source.py
@@ -19,6 +19,13 @@ def test_compile_files(foo_path, vyper_version):
     assert foo_path.as_posix() in output
 
 
+def test_compile_files_multiple_p(foo_path, vyper_version):
+    if Version("0.4.0b1") <= vyper_version <= Version("0.4.0b5"):
+        pytest.skip("vyper 0.4.0b1 to 0.4.0b5 have a bug with combined_json")
+    output = vvm.compile_files([foo_path], base_path=[Path.cwd(), *getsitepackages()])
+    assert foo_path.as_posix() in output
+
+
 def test_compile_standard(input_json, foo_source):
     input_json["sources"] = {"contracts/Foo.vy": {"content": foo_source}}
     result = vvm.compile_standard(input_json)


### PR DESCRIPTION
### What I did

The issue was having to use `type: ignore` on import statements and not properly ensuring i am using the correct types when calling apis, which can find and save bugs.

### How I did it

include a py.typed file with the package

### How to verify it

after installing, should not need to type ignore the imports.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
