### PR TITLE
chore: update action versions and remove outdated classifier/OS name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -7,7 +7,7 @@ about: Report an error that you've encountered.
 * `vvm` Version: x.x.x
 * `vyper` Version: x.x.x
 * Python Version: x.x.x
-* OS: osx/linux/win
+* OS: macOS/linux/win
 
 ### What was wrong?
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Python ${{ matrix.python-version[0] }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version[0] }}
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ install_vyper(version="0.4.0", validate=False)
 
 ## Testing
 
-`vvm` is tested on Linux, OSX and Windows with Vyper versions `>=0.1.0-beta.16`.
+`vvm` is tested on Linux, macOS and Windows with Vyper versions `>=0.1.0-beta.16`.
 
 To run the test suite:
 

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
### What I did

* actions/checkout@v2 and actions/setup-python@v2 are really old
* there is no longer an OS named OSX (hasn't been in over half a decade).
* There were some misleading setup.py classifiers

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
